### PR TITLE
Conversion functions of Ocaml and Coq types

### DIFF
--- a/exec/src/coqnum.mli
+++ b/exec/src/coqnum.mli
@@ -18,8 +18,5 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  *)
 
-val int_of_coqpositive: Constr.constr -> int
-val int_to_coqpositive: int -> Constr.constr
-
 val int_of_coqz: Constr.constr -> int
 val int_to_coqz: int -> Constr.constr

--- a/stdlib/debug/src/debug.ml
+++ b/stdlib/debug/src/debug.ml
@@ -34,8 +34,6 @@ let install_interfaces = register_interfaces @@ fun () -> (
       | Ind (t, _)
         -> if Ind.Z.ref_is t
            then print_int (int_of_coqz term)
-           else if Ind.Positive.ref_is t
-           then print_int (int_of_coqpositive term)
            else if Ind.Bool.ref_is t
            then print_string (if (bool_of_coqbool term) then "true" else "false")
            else if Ind.Ascii.ref_is t

--- a/stdlib/debug/theories/Debug.v
+++ b/stdlib/debug/theories/Debug.v
@@ -33,7 +33,6 @@ Class HasExecIsomorphism (A: Type).
 
 Instance bool_ExecIso: HasExecIsomorphism bool.
 Instance Z_ExecIso: HasExecIsomorphism Z.
-Instance positive_ExecIso: HasExecIsomorphism positive.
 Instance ascii_ExecIso: HasExecIsomorphism ascii.
 Instance string_ExecIso: HasExecIsomorphism string.
 


### PR DESCRIPTION
Two changes about conversion functions:
- New function from Ocaml int to Coq Z.
- The conversions function between Ocaml int and Coq positive are no more exported, because int to positive is a partial function.