### PR TITLE
refactor: Rewrite of the Coqstr module

### DIFF
--- a/exec/src/coqstr.mli
+++ b/exec/src/coqstr.mli
@@ -21,5 +21,5 @@
 val char_of_coqascii: Constr.constr -> char
 val char_to_coqascii: char -> Constr.constr
 
-val str_of_coqstr: Constr.constr -> string
-val str_to_coqstr: string -> Constr.constr
+val bytes_of_coqstr: Constr.constr -> bytes
+val bytes_to_coqstr: bytes -> Constr.constr

--- a/stdlib/console/src/console.ml
+++ b/stdlib/console/src/console.ml
@@ -24,17 +24,17 @@ open Exec_plugin.Query
 
 
 let scan = read_line
-let echo = print_string
+let echo = print_bytes
 
 let path = ["FreeSpec"; "Stdlib"; "Console"; "Console"]
 
 let install_interfaces = register_interfaces @@ fun () -> (
   new_primitive path "Scan" (function [] ->
-    str_to_coqstr (scan ())
+    bytes_to_coqstr (Bytes.of_string @@ scan ())
   | _ -> assert false);
 
   new_primitive path "Echo" (function [str] ->
-    echo (str_of_coqstr str);
+    echo (bytes_of_coqstr str);
     Ind.Unit.mkConstructor "tt"
   | _ -> assert false)
 )

--- a/stdlib/debug/src/debug.ml
+++ b/stdlib/debug/src/debug.ml
@@ -39,7 +39,7 @@ let install_interfaces = register_interfaces @@ fun () -> (
            else if Ind.Ascii.ref_is t
            then print_char (char_of_coqascii term)
            else if Ind.String.ref_is t
-           then print_string (str_of_coqstr term)
+           then print_bytes (bytes_of_coqstr term)
            else raise (UnsupportedTerm "There is no available isomorphism for this type");
            Ind.Unit.mkConstructor "tt"
       | _


### PR DESCRIPTION
In the previous implementation, the conversion functions were using an intermediary representation in the form of a list of chars. Using a fold-based approach, the algorithm becomes more straightforward, and they also are tail-recursive. I had the idea of this change while reviewing #16 :).

Also, I propose to use `bytes` instead of `string`. I expect (though I haven’t measured it) `bytes_of_coqstr` to be much more effective than `str_of_coqstr` in terms of copy and allocation; and at the very least, there is the `Bytes.to_string` to get a `string` from a `bytes`.

Also, if I understood correctly, in future version of Coq, string will be encoded in array of bytes so… :) 