### PR TITLE
stdlib: Add [CommandLine] interface to get command line args

### DIFF
--- a/run/fsc
+++ b/run/fsc
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+if [ $# -eq 0 ]; then
+	echo "Usage: $0 program_files"
+	exit 1
+fi
+
+output=$(echo $1 | cut -d'.' -f1)
+
+mkdir -p /tmp/FreeSpecCompile
+
+tmpfile=P$(uuidgen | cut -d'-' -f1)
+mkdir /tmp/FreeSpecCompile/$tmpfile
+
+for input in $@; do
+	cp "$input" /tmp/FreeSpecCompile/$tmpfile/
+	cd /tmp/FreeSpecCompile/$tmpfile
+	tar -rf ../$tmpfile.tar "$input"
+	rm -f "$input"
+	cd - > /dev/null
+done
+
+echo '#!/usr/bin/env fsrun' > $output
+cat /tmp/FreeSpecCompile/$tmpfile.tar >> $output
+chmod u+x $output
+
+rm -f /tmp/FreeSpecCompile/$tmpfile.tar
+rmdir /tmp/FreeSpecCompile/$tmpfile

--- a/run/fsrun
+++ b/run/fsrun
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+if [ $# -eq 0 ]; then
+	echo "Usage: $0 program [args]"
+	exit 1
+fi
+
+input=$1
+
+mkdir -p /tmp/FreeSpecRun
+tmpfile=p$(uuidgen | cut -d'-' -f1)
+
+if [ $(head -c2 "$input") == "#!" ]; then
+	tail -n+2 "$input" > /tmp/FreeSpecRun/$tmpfile.v
+else
+	cp "$input" /tmp/FreeSpecRun/$tmpfile.v
+fi
+
+echo 'Exec main.' >> /tmp/FreeSpecRun/$tmpfile.v
+
+export FREESPEC_RUN_ARGC=$#
+for n in $(seq 1 $#); do
+	export FREESPEC_RUN_ARG_$((n - 1))="${!n}"
+done
+
+cd /tmp/FreeSpecRun
+
+coqc $tmpfile.v
+rm -f $tmpfile.v $tmpfile.glob $tmpfile.vo .$tmpfile.aux

--- a/run/fsrun
+++ b/run/fsrun
@@ -8,22 +8,28 @@ fi
 input=$1
 
 mkdir -p /tmp/FreeSpecRun
-tmpfile=p$(uuidgen | cut -d'-' -f1)
+tmpfile=P$(uuidgen | cut -d'-' -f1)
 
-if [ $(head -c2 "$input") == "#!" ]; then
-	tail -n+2 "$input" > /tmp/FreeSpecRun/$tmpfile.v
-else
-	cp "$input" /tmp/FreeSpecRun/$tmpfile.v
-fi
+tail -n+2 "$input" > /tmp/FreeSpecRun/$tmpfile.tar
 
-echo 'Exec main.' >> /tmp/FreeSpecRun/$tmpfile.v
+mkdir /tmp/FreeSpecRun/$tmpfile
+cd /tmp/FreeSpecRun/$tmpfile
+
+progfile=$(tar -xvf ../$tmpfile.tar | cut -d'.' -f1)
+
+echo Require Import FreeSpec.Exec. > ../$tmpfile.v
+for file in $progfile; do
+	echo Require Import $file. >> ../$tmpfile.v
+done
+echo Exec main. >> ../$tmpfile.v
 
 export FREESPEC_RUN_ARGC=$#
 for n in $(seq 1 $#); do
 	export FREESPEC_RUN_ARG_$((n - 1))="${!n}"
 done
 
-cd /tmp/FreeSpecRun
+coqc ../$tmpfile.v
+rm -f *.vo ../$tmpfile.tar ../$tmpfile.v ../$tmpfile.glob ../$tmpfile.vo ../.$tmpfile.aux
 
-coqc $tmpfile.v
-rm -f $tmpfile.v $tmpfile.glob $tmpfile.vo .$tmpfile.aux
+cd - > /dev/null
+rmdir /tmp/FreeSpecRun/$tmpfile

--- a/stdlib/commandLine/META
+++ b/stdlib/commandLine/META
@@ -1,0 +1,12 @@
+package "freespec-stdlib-commandLine" (
+
+    description = "Freespec.Stdlib/CommandLine Plugin"
+    version     = "8.9"
+
+    requires    = "freespec-exec"
+    directory   = "src"
+
+    archive(byte)    = "stdlib_commandLine_plugin.cmo"
+    archive(native)  = "stdlib_commandLine_plugin.cmx"
+
+)

--- a/stdlib/commandLine/Makefile.local
+++ b/stdlib/commandLine/Makefile.local
@@ -1,0 +1,10 @@
+CAMLPKGS := -package freespec-exec
+
+install-extra::
+	ocamlfind install freespec-stdlib-commandLine META src/stdlib_commandLine_plugin.*
+
+uninstall::
+	ocamlfind remove freespec-stdlib-commandLine
+
+merlin-hook::
+	echo 'PKG freespec-exec' >> .merlin

--- a/stdlib/commandLine/_CoqProject
+++ b/stdlib/commandLine/_CoqProject
@@ -1,0 +1,6 @@
+-I src
+-R theories FreeSpec.Stdlib
+
+theories/CommandLine.v
+src/commandLine.ml
+src/stdlib_commandLine_plugin.mlpack

--- a/stdlib/commandLine/configure.sh
+++ b/stdlib/commandLine/configure.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+coq_makefile -f _CoqProject -o Makefile

--- a/stdlib/commandLine/demos/Makefile
+++ b/stdlib/commandLine/demos/Makefile
@@ -1,0 +1,7 @@
+all: PrintArgs
+
+%.vo: %.v
+	coqc $^
+
+%: %.vo
+	fsc $^

--- a/stdlib/commandLine/demos/PrintArgs.v
+++ b/stdlib/commandLine/demos/PrintArgs.v
@@ -1,5 +1,3 @@
-#!/usr/bin/env fsrun
-
 (* FreeSpec
  * Copyright (C) 2018–2019 ANSSI
  *

--- a/stdlib/commandLine/demos/PrintArgs.v
+++ b/stdlib/commandLine/demos/PrintArgs.v
@@ -4,8 +4,7 @@
  * Copyright (C) 2018–2019 ANSSI
  *
  * Contributors:
- * 2019 Thomas Letan <thomas.letan@ssi.gouv.fr>
- * 2019 Yann Régis-Gianas <yrg@irif.fr>
+ * Vincent Tourneur <vincent.tourneur@inria.fr>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -22,12 +21,23 @@
  *)
 
 Require Import FreeSpec.Stdlib.Console.
+Require Import FreeSpec.Stdlib.CommandLine.
 Require Import FreeSpec.Program.
 Require Import Prelude.Control.
+Require Import BinInt.
+Require Import String.
+Require Import Ascii.
 
 Local Open Scope prelude_scope.
 
-Definition hello {ix} `{Use Console.i ix} : Program ix unit :=
-  Console.echo "Hello, world".
+Definition new_line := String "010"%char EmptyString.
 
-Definition main := hello.
+Fixpoint print_args_aux {ix} `{Use Console.i ix} `{Use CommandLine.i ix} (t: Z) (n: nat) : Program ix unit :=
+  match n with
+  | S m => CommandLine.arg (t - ((Z.of_nat m) + 1)) >>= Console.echo;; Console.echo " ";; print_args_aux t m
+  | _ => Console.echo new_line
+  end.
+Definition print_args {ix} `{Use Console.i ix} `{Use CommandLine.i ix} (n: Z) := print_args_aux n (Z.to_nat n).
+
+Definition main {ix} `{Use Console.i ix} `{Use CommandLine.i ix} :=
+  CommandLine.argc >>= print_args.

--- a/stdlib/commandLine/src/commandLine.ml
+++ b/stdlib/commandLine/src/commandLine.ml
@@ -1,11 +1,8 @@
-#!/usr/bin/env fsrun
-
 (* FreeSpec
  * Copyright (C) 2018–2019 ANSSI
  *
  * Contributors:
- * 2019 Thomas Letan <thomas.letan@ssi.gouv.fr>
- * 2019 Yann Régis-Gianas <yrg@irif.fr>
+ * 2019 Vincent Tourneur <vincent.tourneur@inria.fr>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -21,13 +18,17 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  *)
 
-Require Import FreeSpec.Stdlib.Console.
-Require Import FreeSpec.Program.
-Require Import Prelude.Control.
+open Exec_plugin.Coqstr
+open Exec_plugin.Extends
+open Exec_plugin.Coqnum
 
-Local Open Scope prelude_scope.
+let path = ["FreeSpec"; "Stdlib"; "CommandLine"; "CommandLine"]
 
-Definition hello {ix} `{Use Console.i ix} : Program ix unit :=
-  Console.echo "Hello, world".
-
-Definition main := hello.
+let install_interface =
+  let argc = function
+    | [] -> int_to_coqz (int_of_string (Sys.getenv "FREESPEC_RUN_ARGC"))
+    | _ -> assert false in
+  let arg = function
+    | [n] -> string_to_coqstr (Sys.getenv ("FREESPEC_RUN_ARG_" ^ (string_of_int (int_of_coqz n))))
+    | _ -> assert false in
+  register_interface path [("Argc", argc); ("Arg", arg)]

--- a/stdlib/commandLine/src/stdlib_commandLine_plugin.mlpack
+++ b/stdlib/commandLine/src/stdlib_commandLine_plugin.mlpack
@@ -1,0 +1,1 @@
+CommandLine

--- a/stdlib/commandLine/theories/CommandLine.v
+++ b/stdlib/commandLine/theories/CommandLine.v
@@ -1,11 +1,8 @@
-#!/usr/bin/env fsrun
-
 (* FreeSpec
  * Copyright (C) 2018–2019 ANSSI
  *
  * Contributors:
- * 2019 Thomas Letan <thomas.letan@ssi.gouv.fr>
- * 2019 Yann Régis-Gianas <yrg@irif.fr>
+ * 2019 Vincent Tourneur <vincent.tourneur@inria.fr>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -21,13 +18,23 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  *)
 
-Require Import FreeSpec.Stdlib.Console.
+Require Import FreeSpec.Exec.
+Require Export Coq.Strings.String.
 Require Import FreeSpec.Program.
-Require Import Prelude.Control.
+Require Import BinInt.
 
-Local Open Scope prelude_scope.
+Module CommandLine.
+  Inductive i: Type -> Type :=
+  | Argc: i Z
+  | Arg: Z -> i string.
 
-Definition hello {ix} `{Use Console.i ix} : Program ix unit :=
-  Console.echo "Hello, world".
+  Definition argc {ix} `{Use i ix}
+    : Program ix Z :=
+    request Argc.
 
-Definition main := hello.
+  Definition arg {ix} `{Use i ix} (n: Z)
+    : Program ix string :=
+    request (Arg n).
+End CommandLine.
+
+Declare ML Module "stdlib_commandLine_plugin".

--- a/stdlib/console/demos/Hello.v
+++ b/stdlib/console/demos/Hello.v
@@ -1,5 +1,3 @@
-#!/usr/bin/env fsrun
-
 (* FreeSpec
  * Copyright (C) 2018–2019 ANSSI
  *

--- a/stdlib/console/demos/Makefile
+++ b/stdlib/console/demos/Makefile
@@ -1,0 +1,7 @@
+all: Hello
+
+%.vo: %.v
+	coqc $^
+
+%: %.vo
+	fsc $^


### PR DESCRIPTION
In order to get command line arguments from the Coq side, the program
must be run with the `fsrun` script (in the `run` directory). It uses
environment variables to transmit the args given by the user. It is also
no longer necessary to add `Exec xxx.` at the end of the program file,
since `fsrun` will append `Exec main.` to the file when calling `coqc`.
`fsrun` will also remove the first line of the program file if it begins
with `#!`, so it is possible to add `#!/usr/bin/env fsrun` and run the
program with `./Prog.v`, if `fsrun` is accesible in the environment path.