### PR TITLE
Make use of the new attribute mechanism of Coq

### DIFF
--- a/core/theories/Program.v
+++ b/core/theories/Program.v
@@ -204,8 +204,9 @@ Definition program_map
   : Program I B :=
   program_bind p (fun x => Pure (f x)).
 
-Program Instance program_Functor
-        (I:  Interface)
+#[program]
+Instance program_Functor
+         (I:  Interface)
   : Functor (Program I) :=
   { map := @program_map I
   }.
@@ -246,8 +247,9 @@ Proof.
   reflexivity.
 Qed.
 
-Polymorphic Program Instance program_Applicative
-            (I:  Interface)
+#[polymorphic, program]
+Instance program_Applicative
+         (I:  Interface)
   : Applicative (Program I) :=
   { pure := @program_pure I
   ; apply := @program_apply I
@@ -281,8 +283,9 @@ Next Obligation. (* program_apply (program_apply (program_apply (program_pure co
   reflexivity.
 Defined.
 
-Program Instance program_Monad
-        (I:  Interface)
+#[program]
+Instance program_Monad
+         (I:  Interface)
   : Monad (Program I) :=
   { bind := @program_bind I
   }.

--- a/experiment/theories/Row.v
+++ b/experiment/theories/Row.v
@@ -255,10 +255,11 @@ Notation "<<| x ; y ; .. ; z |>>" :=
 (** * Specification
  *)
 
-Polymorphic Fixpoint generalize'
-            (f:      Type -> (Type -> Type) -> Type)
-            (specs:  list Type)
-            (row:    list (Type -> Type))
+#[polymorphic]
+Fixpoint generalize'
+         (f:      Type -> (Type -> Type) -> Type)
+         (specs:  list Type)
+         (row:    list (Type -> Type))
   : list Type :=
   match specs, row with
   | w :: rst, i :: rst'


### PR DESCRIPTION
I was not aware that `program` and `polymorphic` were already supported by the attribute mechanism of Coq. I personally really like it, and find the code clearer when we use it.