### PR TITLE
feature: Add a convenient notation to reduce [Use] verbosity

### DIFF
--- a/core/theories/Compose.v
+++ b/core/theories/Compose.v
@@ -58,18 +58,16 @@ Infix "<+>" :=
 Local Open Scope free_scope.
 
 Instance IntCompose_Use_L
-         (ix i j:  Interface)
-        `{Use i ix}
-  : Use i (ix <+> j) :=
+         (ix i j:  Interface) `{ix :| i}
+  : ix <+> j :| i :=
   { lift_eff := fun (a:  Type)
                     (e:  i a)
                 => InL (lift_eff e)
   }.
 
 Instance IntCompose_Use_R
-         (j i jx:  Interface)
-        `{Use j jx}
-  : Use j (i <+> jx) :=
+         (j i jx:  Interface) `{jx :| j}
+  : i <+> jx :| j :=
   { lift_eff := fun (a:  Type)
                     (e:  j a)
                 => InR (lift_eff e)

--- a/core/theories/Undefined.v
+++ b/core/theories/Undefined.v
@@ -60,7 +60,7 @@ Inductive Undefined
  *)
 
 Definition undef
-           {ix:  Type -> Type} `{Use Undefined ix}
+           {ix:  Type -> Type} `{ix :| Undefined}
            {a:   Type}
   : Program ix a :=
   request undefined.

--- a/examples/Airlock.v
+++ b/examples/Airlock.v
@@ -63,10 +63,10 @@ Module controller.
   | Tick: i unit
   | OpenDoor: door -> i unit.
 
-  Definition tick {Ix} `{Use i Ix}: Program Ix unit :=
+  Definition tick {Ix} `{(i | Ix)}: Program Ix unit :=
     request Tick.
 
-  Definition open_door {Ix} `{Use i Ix}: door -> Program Ix unit :=
+  Definition open_door {Ix} `{(i | Ix)}: door -> Program Ix unit :=
     request <<< OpenDoor.
 End controller.
 
@@ -80,17 +80,17 @@ Module door.
   Arguments IsOpen {L l}.
   Arguments Toggle {L l}.
 
-  Definition is_open {L Ix} (l: L) `{Use (i l) Ix}: Program Ix bool :=
+  Definition is_open {L Ix} (l: L) `{(i l | Ix)}: Program Ix bool :=
     request IsOpen.
 
-  Definition toggle {L Ix} (l: L) `{Use (i l) Ix}: Program Ix unit :=
+  Definition toggle {L Ix} (l: L) `{(i l | Ix)}: Program Ix unit :=
     request Toggle.
 End door.
 
 #[program]
 Instance use_door
          (l: door)
-  : Use (door.i l) (door.i In <+> door.i Out) :=
+  : (door.i l | door.i In <+> door.i Out) :=
   { lift_eff :=  match l with
                  | In => fun _ op => InL op
                  | Out => fun _ op => InR op
@@ -99,11 +99,11 @@ Instance use_door
 
 (** * Controller Model *)
 
-Definition open_door {L Ix} (l: L) `{Use (door.i l) Ix}: Program Ix unit :=
+Definition open_door {L Ix} (l: L) `{(door.i l | Ix)}: Program Ix unit :=
   d <- door.is_open l;
   when (negb d) $ door.toggle l.
 
-Definition close_door {L Ix} (l: L) `{Use (door.i l) Ix}: Program Ix unit :=
+Definition close_door {L Ix} (l: L) `{(door.i l | Ix)}: Program Ix unit :=
   d <- door.is_open l;
   when d $ door.toggle l.
 

--- a/examples/combine.v
+++ b/examples/combine.v
@@ -29,16 +29,9 @@ Local Open Scope Z_scope.
 
 Local Open Scope prelude_scope.
 
-Definition combine {ix} `{Use Console.i ix} `{Use Debug.i ix}: Program ix unit :=
+Definition combine {ix} `{ix :| Console.i, Debug.i}: Program ix unit :=
   Debug.iso 10 >>= Debug.inspect >>= Console.echo ;;
   Debug.iso true >>= Debug.inspect >>= Console.echo.
 
 (* for Console.i <+> Debug.i *)
 Exec combine.
-
-Axiom (ix: Type -> Type).
-Axiom (Use_console_ix: Use Console.i ix).
-Axiom (Use_debug_ix: Use Debug.i ix).
-
-(* for the most generic form *)
-Exec (@combine ix Use_console_ix Use_debug_ix).

--- a/examples/hello.v
+++ b/examples/hello.v
@@ -24,7 +24,7 @@ Require Import Prelude.Control.
 
 Local Open Scope prelude_scope.
 
-Definition hello {ix} `{Use Console.i ix} : Program ix unit :=
+Definition hello {ix} `{ix :| Console.i} : Program ix unit :=
   Console.echo "Hello, world".
 
 Exec hello.


### PR DESCRIPTION
This patch introduces the notation `ix :| i1, i2, i3` (“ix provides i1, i2 and i3”) to be used in place of `Use i1 ix, Use i2 ix, Use i3 ix`.

Thus, where we had to write

```coq
Definition my_program {ix} `{Use Console.i ix, Use Debug.i ix}
  : Program ix A :=
  (* ... *)
```
We can now write

```coq
Definition my_program {ix} `{ix :| Console.i, Debug.i}
  : Program ix A :=
  (* ... *)
```
    
The resulting type are (at least to the author opinion) easier to read, and looks a lot like PureScript row of effects.  The ordering of the interfaces within the row is not important, and Coq typeclasses inference mechanism handles this just fine.
