### PR TITLE
chore: Fix the documentation build

### DIFF
--- a/exec/src/freespec_exec.mlpack
+++ b/exec/src/freespec_exec.mlpack
@@ -1,10 +1,12 @@
 Utils
 Query
-Coqsum
-Coqprod
-Coqnum
 Coqbool
+Coqbyte
+Coqlist
+Coqnum
+Coqprod
 Coqstr
+Coqsum
 Coqunit
 Interfaces
 Extends


### PR DESCRIPTION
As long as dune does not provide a way to build the documentation of a
Coq project, we need to keep .mlpack files around for
plugins. Unfortunately, the mlpack file of Exec was seriously
outdated. We fix that, and this should bring the FreeSpec CI back to
business.

This should fix #43 