### PR TITLE
chore: Use the latest version of the dune configuration syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
     - COMPILER="4.08.0"
     - NATIVE_COMP="yes"
     - COQ_VER="8.11.0"
-    - DUNE_VER="2.1.3"
+    - DUNE_VER="2.4.0"
     - OPAMVERBOSE=3
     - COQ_PRELUDE_HASH="193d9550258a57f6c68e3ba098ae95df779aafa5"
 

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,9 @@ docs:
 	@mv mlihtml docs/ml
 
 install: clean
-	@cd core;   dune build; dune install; cd -
-	@cd exec;   dune build; dune install; cd -
-	@cd stdlib; dune build; dune install; cd -
+	@cd core;   dune build @install; dune install; cd -
+	@cd exec;   dune build @install; dune install; cd -
+	@cd stdlib; dune build @install; dune install; cd -
 
 mrproper: clean
 	@cd core;   dune clean; cd -

--- a/core/dune-project
+++ b/core/dune-project
@@ -1,3 +1,3 @@
-(lang dune 1.11)
+(lang dune 2.4)
 (using coq 0.1)
 (name freespec-core)

--- a/core/theories/dune
+++ b/core/theories/dune
@@ -1,6 +1,6 @@
 (coq.theory
   (name FreeSpec)
-  (public_name freespec-core.theories)
+  (package freespec-core)
   (modules Core
            Core.Interface
            Core.Impure

--- a/exec/dune-project
+++ b/exec/dune-project
@@ -1,3 +1,3 @@
-(lang dune 1.11)
+(lang dune 2.4)
 (using coq 0.1)
 (name freespec-exec)

--- a/exec/theories/dune
+++ b/exec/theories/dune
@@ -1,6 +1,6 @@
 (coq.theory
   (name FreeSpec)
-  (public_name freespec-exec.theories)
+  (package freespec-exec)
   (libraries freespec-exec.plugin)
   (modules Exec Exec.Debug Exec.Eval))
 

--- a/stdlib/dune-project
+++ b/stdlib/dune-project
@@ -1,3 +1,3 @@
-(lang dune 1.11)
+(lang dune 2.4)
 (using coq 0.1)
 (name freespec-stdlib)

--- a/stdlib/theories/dune
+++ b/stdlib/theories/dune
@@ -1,6 +1,6 @@
 (coq.theory
   (name FreeSpec)
-  (public_name freespec-stdlib.theories)
+  (package freespec-stdlib)
   (libraries freespec-stdlib.console
              freespec-stdlib.env
              freespec-stdlib.files)


### PR DESCRIPTION
Dune configuration file syntax is versioned, and with this commit we
explicitly use the 2.4 version of dune. We do that because the Coq
support of dune remains experimental, and therefore is subject to
change. For instance, the public_name stanza has been deprecated, and
there is no reason to continue using it. Besides, dune will soon add
support for compositional build of Coq libraries and we really want to
use that.