### PR TITLE
feature: Reason about impure computations using Hoare logic

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -11,8 +11,11 @@ core/theories/Core.v
 core/theories/Core/Interface.v
 core/theories/Core/Semantics.v
 core/theories/Core/Component.v
+core/theories/Core/Morphism.v
 core/theories/Core/Impure.v
 core/theories/Core/Contract.v
+core/theories/Core/Hoare.v
+core/theories/Core/Hoare/Monad.v
 core/theories/Core/Tactics.v
 
 exec/theories/Exec.v

--- a/core/theories/Core/Hoare.v
+++ b/core/theories/Core/Hoare.v
@@ -1,0 +1,140 @@
+(* FreeSpec
+ * Copyright (C) 2018–2020 ANSSI
+ *
+ * Contributors:
+ * 2018–2020 Thomas Letan <thomas.letan@ssi.gouv.fr>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *)
+
+From Prelude Require Import All.
+From FreeSpec Require Import Impure Contract Morphism Tactics.
+
+(** If we consider the monad form by the set of sets of predicates, that is
+
+<<
+Definition predicate (a : Type) : Type := a -> Prop.
+>>
+
+    whose [bind] and [pure] functions is defined as follows
+
+<<
+Definition predicat_bind {α β} (p : predicate α) (f : α -> predicate β)
+  : predicate β :=
+  fun r => exists (x : α), p x /\ (f x) r.
+
+Definition predicat_pure {α} (x : α) : predicate α := eq x.
+>>
+
+    Then, given [f := fun α e => fun x => True] the morphism from the interface
+    type [i] to [predicate] such that [f α e] is a predicate which is always
+    satisfied, [morphism_lift f p] is a predicate which allows for reasoning
+    about any potential output of [p] (that is, considering any implementer for
+    [i]).
+
+    The [hoare] monad is another interesting candidate for reifying our [impure]
+    monad, and we demonstrate here that we can easily provide a morphism from
+    [impure] to [hoare], to the extent that we provide a contract to generate
+    the [pre] and [post] condition of the hoare monad.
+
+    We define the [hoare_of_contract] morphism parameterized by a contract [c]
+    to project primitives of an interface to the [hoare] monad. This morphism
+    use the obligations of [c] to define the precondition and postcondition of
+    the resulting [hoare] monadic term. *)
+
+Definition hoare_of_contract `{MayProvide ix i} {Ω} (c : contract i Ω)
+  : ix ~> hoare Ω :=
+  fun α (e : ix α) =>
+    mk_hoare (fun ω => gen_caller_obligation c ω e)
+             (fun ω x ω' =>
+                gen_callee_obligation c ω e x
+                /\ ω' = gen_witness_update c ω e x).
+
+Definition hoare_of_impure `{MayProvide ix i} {Ω} (c : contract i Ω)
+  : impure ix ~> hoare Ω :=
+  morphism_lift (hoare_of_contract c).
+
+Arguments hoare_of_impure {ix i H Ω} (c) {α} _.
+
+(** Then, we demonstrate that, considering [hp] the (hoare) monad computed
+    thanks to [hoare_of_contract] and [morphism_lift], and an impure computation
+    [p]
+
+      - [respectful_impure_equivalence]: If a witness state [ω] satisfies the
+        pre condition of [hp], then [p] is respectful wrt. [c] in accordance to
+        [ω] (see [respectful_impure]).
+      - [respectful_run_equivalence]: Similarly, if a tuple [(ω, x, ω')]
+        satisfies the post condition [hp], then there exists a respectful run
+        from [ω] to compute [x] and [ω'] (see [respectful_run]). *)
+
+Lemma respectful_impure_equivalence  `{MayProvide ix i} {α Ω}
+    (c : contract i Ω) (ω : Ω) (p : impure ix α)
+  : respectful_impure c ω p <-> pre (hoare_of_impure c p) ω.
+
+Proof.
+  revert ω.
+  induction p; intros ω.
+  + split; cbn.
+    ++ auto.
+    ++ intros _.
+       constructor.
+  + cbn.
+    split.
+    ++ intros r.
+       inversion r; ssubst.
+       split; [ exact req |].
+       intros x s'.
+       intros [post equ].
+       specialize next with x.
+       apply next in post.
+       apply H0 in post.
+       rewrite equ.
+       apply post.
+    ++ intros [p r1].
+       constructor; [ exact p |].
+       intros x q.
+       rewrite H0.
+       apply r1.
+       split; [ exact q | reflexivity ].
+Qed.
+
+Lemma respectful_run_equivalence  `{MayProvide ix i} {α Ω}
+    (c : contract i Ω) (p : impure ix α) (ω : Ω) (x : α) (ω' : Ω)
+    (h : respectful_impure c ω p)
+  : respectful_run c p ω ω' x <-> post (hoare_of_impure c p) ω x ω'.
+
+Proof.
+  revert ω ω' x h.
+  induction p; intros ω ω' r h.
+  + split; cbn.
+    ++ intros run.
+       unroll_respectful_run run; auto.
+    ++ intros [r1 r2].
+       subst.
+       constructor.
+  + inversion h; ssubst.
+    split.
+    ++ intros run.
+       inversion run; ssubst.
+       cbn.
+       exists x.
+       exists (gen_witness_update c ω e x).
+       repeat split; auto.
+       apply H0; auto.
+    ++ intros [t [ω'' [[r1 r2] r3]]]; subst.
+       econstructor.
+       +++ apply req.
+       +++ apply r1.
+       +++ apply H0; auto.
+Qed.

--- a/core/theories/Core/Hoare/Monad.v
+++ b/core/theories/Core/Hoare/Monad.v
@@ -1,0 +1,434 @@
+(* FreeSpec
+ * Copyright (C) 2018–2020 ANSSI
+ *
+ * Contributors:
+ * 2018–2020 Thomas Letan <thomas.letan@ssi.gouv.fr>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *)
+
+From Coq Require Import Equivalence Setoid Morphisms.
+From Prelude Require Import All.
+
+(** * Definition *)
+
+Record hoare (Σ : Type) (α : Type) : Type :=
+  mk_hoare { pre : Σ -> Prop
+           ; post : Σ -> α -> Σ -> Prop
+           }.
+
+Arguments mk_hoare {Σ α} (pre post).
+Arguments pre {Σ α} (_ _).
+Arguments post {Σ α} (_ _ _).
+
+Definition hoare_pure {Σ α} (x : α) : hoare Σ α :=
+  mk_hoare (fun _ => True) (fun s y s' => x = y /\ s = s').
+
+Definition hoare_bind {Σ α β} (h : hoare Σ α) (k : α -> hoare Σ β) : hoare Σ β :=
+  mk_hoare (fun s => pre h s /\ (forall x s', post h s x s' -> pre (k x) s'))
+           (fun s x s'' => exists y s', post h s y s' /\ post (k y) s' x s'').
+
+(** * Instances *)
+
+(* TODO: use `begin details` when coq.8.12 is released *)
+(* begin hide *)
+
+(** Reasoning with the [hoare] type has proven to be cumbersome to say the
+    least. However, one can use the automation features of Coq to ease the
+    verification process.
+
+    More precisely, we implement several “angry”, ad-hoc tactics. *)
+
+Lemma iff_p_p (p : Prop) : (p <-> p) <-> True.
+
+Proof.
+  now split.
+Qed.
+
+Lemma prop_and_neutral (p : Prop) : (True /\ p) <-> p.
+
+Proof.
+  now repeat split.
+Qed.
+
+Lemma imply_true_true (p : Type) : (p -> True) <-> True.
+
+Proof.
+  now repeat split.
+Qed.
+
+Lemma and_imply_equ (p q r : Prop) : (p /\ q -> r) <-> (p -> q -> r).
+
+Proof.
+  split.
+  + intros H hp hq.
+    apply H.
+    now split.
+  + intros H [hp hq].
+    now apply H.
+Qed.
+
+Lemma alias_equ {a} (x : a) (p : a -> Prop)
+  : (forall (y : a), y = x -> p y) <-> p x.
+
+Proof.
+  split.
+  + intros H.
+    now apply (H x).
+  + intros hx y equ.
+    now rewrite equ.
+Qed.
+
+Lemma forall_equ_2 {a b} (x : a) (y : b) (p : a -> b -> Prop)
+  : (forall (x' : a) (y' : b), x = x' -> y = y' -> p x' y') <-> p x y.
+
+Proof.
+  split.
+  + intros H.
+    now apply H.
+  + intros hxy x' y' equ1 equ2.
+    now subst.
+Qed.
+
+Lemma forall_equ_2' {a b} (x : a) (y : b) (p : a -> b -> Prop)
+  : (forall (x' : a) (y' : b), x' = x -> y' = y -> p x' y') <-> p x y.
+
+Proof.
+  split.
+  + intros H.
+    now apply H.
+  + intros hxy x' y' equ1 equ2.
+    now subst.
+Qed.
+
+Lemma exists_equ_2 {a b} (x : a) (y : b) (p : a -> b -> Prop)
+  : (exists (x' : a) (y' : b), (x = x' /\ y = y') /\ p x' y') <-> p x y.
+
+Proof.
+  split.
+  + intros H.
+    now destruct H as [x' [y' [[equ1 equ2] H]]]; subst.
+  + intros hxy.
+    exists x.
+    exists y.
+    now split.
+Qed.
+
+Lemma exists_equ_2' {a b} (x : a) (y : b) (p : a -> b -> Prop)
+  : (exists (x' : a) (y' : b), (x' = x /\ y' = y) /\ p x' y') <-> p x y.
+
+Proof.
+  split.
+  + intros H.
+    now destruct H as [x' [y' [[equ1 equ2] H]]]; subst.
+  + intros hxy.
+    exists x.
+    exists y.
+    now split.
+Qed.
+
+Lemma eq_sym_equ {a} (x y : a) : x = y <-> y = x.
+
+Proof.
+  now repeat split.
+Qed.
+
+Ltac angry_rewrite :=
+  repeat (
+      setoid_rewrite prop_and_neutral
+      || setoid_rewrite imply_true_true
+      || setoid_rewrite (and_comm _ True)
+      || setoid_rewrite (and_comm _ (_ /\ _))
+      || setoid_rewrite and_imply_equ
+      || setoid_rewrite forall_equ_2
+      || setoid_rewrite exists_equ_2
+      || setoid_rewrite exists_equ_2'
+      || setoid_rewrite iff_p_p
+    ).
+
+Ltac angry_destruct H :=
+  match type of H with
+  | _ /\ _ => let H' := fresh "H" in
+              let H'' := fresh "H" in
+              destruct H as [H' H''];
+              angry_destruct H';
+              angry_destruct H''
+  | exists _, _ => let x := fresh "x" in
+                   let H' := fresh "H" in
+                   destruct H as [x H']; angry_destruct H'
+  | _ => idtac
+  end.
+
+Ltac angry_intros :=
+  let H := fresh "H" in
+  intros H; angry_destruct H.
+
+Ltac angry_exists :=
+  repeat (eexists; eauto).
+(* end hide *)
+
+(** ** [Equality] *)
+
+Inductive hoare_eq {Σ α} (h1 h2 : hoare Σ α) : Prop :=
+| mk_hoare_eq
+    (pre_eq : forall s, pre h1 s <-> pre h2 s)
+    (post_eq : forall s x s', post h1 s x s' <-> post h2 s x s')
+  : hoare_eq h1 h2.
+
+Lemma hoare_eq_refl {Σ α} (h : hoare Σ α) : hoare_eq h h.
+
+Proof. easy. Qed.
+
+Lemma hoare_eq_sym {Σ α} (h1 h2 : hoare Σ α) : hoare_eq h1 h2 -> hoare_eq h2 h1.
+
+Proof.
+  intros equ.
+  constructor;
+    symmetry;
+    apply equ.
+Qed.
+
+Lemma hoare_eq_trans {Σ α} (h1 h2 h3 : hoare Σ α)
+    (equ_1_2 : hoare_eq h1 h2) (equ_2_3 : hoare_eq h2 h3)
+  : hoare_eq h1 h3.
+
+Proof.
+  constructor.
+  + intros s.
+    transitivity (pre h2 s); [ apply equ_1_2 | apply equ_2_3 ].
+  + intros s x s'.
+    transitivity (post h2 s x s'); [ apply equ_1_2 | apply equ_2_3 ].
+Qed.
+
+#[refine]
+Instance hoare_eq_Equivalence : Equivalence (@hoare_eq Σ α) := {}.
+
+Proof.
+  + intros h.
+    apply hoare_eq_refl.
+  + intros h h'.
+    apply hoare_eq_sym.
+  + intros h h' h''.
+    apply hoare_eq_trans.
+Qed.
+
+#[program]
+Instance hoare_eq_Equality : Equality (@hoare Σ α) :=
+  { equal := hoare_eq
+  }.
+
+#[program]
+Instance pre_Proper : Proper ('equal ==> eq ==> iff) (@pre Σ α).
+
+Next Obligation.
+  add_morphism_tactic.
+  intros h1 h2 equ s.
+  apply equ.
+Qed.
+
+#[program]
+Instance post_Proper : Proper ('equal ==> eq ==> eq ==> eq ==> iff) (@post Σ α).
+
+Next Obligation.
+  add_morphism_tactic.
+  intros h1 h2 equ s x s'.
+  apply equ.
+Qed.
+
+(** ** [Functor] *)
+
+Definition hoare_map {Σ α β} (f : α -> β) (h : hoare Σ α) : hoare Σ β :=
+  hoare_bind h (fun x => hoare_pure (f x)).
+
+#[refine]
+Instance hoare_Functor : Functor (hoare Σ) :=
+  { map := fun _ _ => hoare_map
+  }.
+
+Proof.
+  all: cbn; intros; (constructor; [ intros s; now cbn |]).
+  + intros s r s'.
+    split; cbn.
+    ++ now angry_rewrite.
+    ++ now angry_rewrite.
+  + intros s r s'.
+    split; cbn.
+    ++ angry_intros; subst.
+       angry_rewrite.
+       angry_exists.
+    ++ angry_intros; subst.
+       angry_exists.
+Defined.
+
+(** ** [Applicative] *)
+
+Definition hoare_apply {Σ α β} (hf : hoare Σ (α -> β)) (h : hoare Σ α)
+  : hoare Σ β :=
+  hoare_bind hf (fun f => hoare_map f h).
+
+Lemma hoare_apply_id `{Equality α} {Σ} (v : hoare Σ α)
+   : hoare_eq (hoare_apply (hoare_pure id) v) v.
+
+Proof.
+  constructor.
+  all: intros; cbn ; now angry_rewrite.
+Qed.
+
+Lemma hoare_apply_compose `{Equality γ} {Σ α β}
+    (u : hoare Σ (β -> γ)) (v : hoare Σ (α -> β)) (w : hoare Σ α)
+  : hoare_eq (hoare_apply (hoare_apply (hoare_apply (hoare_pure compose) u) v) w)
+             (hoare_apply u (hoare_apply v w)).
+
+Proof.
+  constructor; intros; cbn.
+  + angry_rewrite.
+    rewrite and_assoc.
+    rewrite <- (and_iff_compat_l (pre u s)); [ reflexivity |].
+    angry_rewrite.
+    split.
+    ++ intros; split.
+       +++ intros.
+           angry_destruct H1; subst.
+           specialize (H0 x0 s' H3).
+           now destruct H0 as [H0 _].
+       +++ repeat angry_intros; subst.
+           specialize (H0 x1 x0 H6).
+           destruct H0 as [_ H0].
+           eapply H0.
+           exact H8.
+    ++ intros [H1 H2] x s' q.
+       split.
+       +++ eapply H1.
+           angry_exists.
+       +++ intros f s'' q'.
+           eapply H2.
+           angry_exists.
+  + angry_rewrite.
+    split;
+       intros Hex;
+       angry_destruct Hex; subst;
+       repeat (eexists; eauto).
+Qed.
+
+Lemma hoare_apply_pure {Σ α} `{Equality β}
+    (v : α -> β) (x : α)
+  : hoare_eq (Σ := Σ) (hoare_apply (hoare_pure v) (hoare_pure x)) (hoare_pure (v x)).
+
+Proof.
+  constructor; cbn.
+  angry_rewrite; auto.
+  intros s y s'.
+  split.
+  + intros [f [s'' [[equ1 equ2] [z [s''' H1]]]]].
+    now intuition; subst.
+  + angry_intros; subst.
+    angry_exists.
+Qed.
+
+Lemma hoare_pure_apply {Σ α} `{Equality β}
+    (u : hoare Σ (α -> β)) (y : α)
+  : hoare_eq (hoare_apply u (hoare_pure y))
+             (hoare_apply (hoare_pure (fun z => z y)) u).
+
+Proof.
+  constructor; cbn.
+  + now angry_rewrite.
+  + intros.
+    split;
+      angry_intros;
+      subst;
+      angry_exists.
+Qed.
+
+Lemma hoare_map_hoare_apply {Σ α} `{Equality β}
+    (g : α -> β) (x : hoare Σ α)
+  : hoare_eq (hoare_map g x) (hoare_apply (hoare_pure g) x).
+
+Proof.
+  constructor; cbn; intros; now angry_rewrite.
+Qed.
+
+#[refine]
+Instance hoare_Applicative : Applicative (hoare Σ) :=
+  { apply := fun _ _ => hoare_apply
+  ; pure := fun _ => hoare_pure
+  }.
+
+Proof.
+  all: cbn; intros.
+  + apply hoare_apply_id.
+  + apply hoare_apply_compose.
+  + apply hoare_apply_pure.
+  + apply hoare_pure_apply.
+  + apply hoare_map_hoare_apply.
+Defined.
+
+(** ** [Monad] *)
+
+Lemma hoare_bind_pure {Σ α} `{Equality β} (x : α) (f : α -> hoare Σ β)
+  : hoare_eq (hoare_bind (hoare_pure x) f) (f x).
+
+Proof.
+  constructor; cbn; intros; now angry_rewrite.
+Qed.
+
+#[refine]
+Instance hoare_Monad : Monad (hoare Σ) :=
+  { bind := fun _ _ => hoare_bind
+  }.
+
+Proof.
+  all: cbn; intros.
+  + apply hoare_bind_pure.
+  + constructor.
+    ++ intros s.
+       now cbn.
+    ++ intros s r s'; cbn; split.
+       +++ now angry_intros; subst.
+       +++ repeat angry_intros; subst.
+           angry_exists.
+  + constructor.
+    ++ intros s.
+       split; cbn.
+       +++ angry_intros.
+           split; auto.
+           intros x s' q.
+           split; auto.
+           intros t s'' q'.
+           apply H2.
+           angry_exists.
+       +++ angry_intros.
+           repeat (split; auto).
+           ++++ intros x s' q.
+                now apply H2.
+           ++++ repeat angry_intros.
+                eapply H2; eauto.
+    ++ intros s x s'.
+       cbn.
+       split.
+       +++ angry_intros.
+           angry_exists.
+       +++ angry_intros.
+           angry_exists.
+  + constructor.
+    ++ intros s.
+       cbn.
+       setoid_rewrite H0.
+       reflexivity.
+    ++ intros s r s'.
+       cbn.
+       setoid_rewrite H0.
+       reflexivity.
+  + reflexivity.
+Defined.

--- a/core/theories/Core/Morphism.v
+++ b/core/theories/Core/Morphism.v
@@ -1,0 +1,86 @@
+(* FreeSpec
+ * Copyright (C) 2018–2020 ANSSI
+ *
+ * Contributors:
+ * 2018–2020 Thomas Letan <thomas.letan@ssi.gouv.fr>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *)
+
+From Prelude Require Import All.
+From FreeSpec Require Import Impure Contract Tactics.
+From FreeSpec Require Export Hoare.Monad.
+
+(** In _Dijkstra Monads for Free_, Ahman et al. explore the idea of “reifying”
+    computations encoded in an “effectful” computation into a “specification”
+    monad, more suitable for reasoning.
+
+    From a high-level perspective, a reification function from a computation
+    into a monad [m] to another monad [w] is a morphism to project terms of [m
+    a] (for any [a]) to terms of [w a]. *)
+
+Definition second_order_morphism (m : Type -> Type) (w : Type -> Type) :=
+  forall (α : Type), m α -> w α.
+
+Infix "~>" := second_order_morphism (at level 80, no associativity) : type_scope.
+
+(** Interestingly, FreeSpec provides since the very start an example of such a
+    function: [run_impure]. Indeed, what [run_impure] actually does is reifying
+    a computation encoded in the [impure] monad to the [state] monad, which is a
+    pure, computable value as far as Coq is concerned. *)
+
+Definition run_impure_reify {i} : impure i ~> state (semantics i) :=
+  fun _ p sem => (fun x => (interp_result x, interp_next x)) $ run_impure sem p.
+
+(** Even more interesting: the definition of [impure] allows us to consider a
+    more general approach to construct morphism from [impure] to a monad [w]. We
+    just need to have a morphism from the interface type [i] to the monad
+    [w]. *)
+
+Definition morphism_lift `{Monad w} {i} (s : i ~> w) : impure i ~> w :=
+  fix rec (α : Type) (p : impure i α) :=
+    match p with
+    | local x => pure x
+    | request_then e f => bind (s _ e) (fun x => rec α (f x))
+    end.
+
+(** This allows for neat tricks.
+
+    For instance, [run_impure_reify] (and therefore [run_impure]) can be
+    reimplemented using [run_effect] and [morphism_lift]. *)
+
+Definition run_impure_reify' {i} : impure i ~> state (semantics i) :=
+  morphism_lift
+    (fun* _ e sem =>
+       (fun x => (interp_result x, interp_next x)) <$> run_effect sem e).
+
+Lemma run_impure_equiv `{Equality α} {i} (p : impure i α)
+  : run_impure_reify _ p == run_impure_reify' _ p.
+
+Proof.
+  induction p.
+  + reflexivity.
+  + intros sem.
+    replace (run_impure_reify α (request_then e f) sem)
+      with (run_impure_reify α (f (interp_result $ run_effect sem e))
+                             (interp_next $ run_effect sem e)); [| reflexivity].
+    replace (run_impure_reify' α (request_then e f) sem)
+      with (run_impure_reify' α (f (interp_result $ run_effect sem e))
+                             (interp_next $ run_effect sem e)); [| reflexivity].
+    apply H0.
+Qed.
+
+(** But we can also consider other monads, more suitable for reasoning about
+    impure computations. In particular, the [hoare] monad allows for reasoning
+    about impure computations in terms of precondition and postcondition. *)

--- a/core/theories/dune
+++ b/core/theories/dune
@@ -1,12 +1,5 @@
 (coq.theory
   (name FreeSpec)
-  (package freespec-core)
-  (modules Core
-           Core.Interface
-           Core.Impure
-           Core.Semantics
-           Core.Component
-           Core.Contract
-           Core.Tactics))
+  (package freespec-core))
 
 (include_subdirs qualified)


### PR DESCRIPTION
See the commit message for more information

------------------------

This is a draft PR, feedback is welcome, although everything can change very quickly.

**TODO:**

- [x] Prove [hoare] is a monad
- [x] Prove the equivalence between the FreeSpec respectfulness and Hoare pre/post condition
- [x] Document at length

**Not in this PR:**

- Remove `respectful_run` and `respectful_impure`; for now, they stay the primary reasoning principles FreeSpec users will interact with.