### PR TITLE
fix: Declare Monad instance explicitly

### DIFF
--- a/theories/Core/Instrument.v
+++ b/theories/Core/Instrument.v
@@ -1,4 +1,5 @@
 From ExtLib Require Import StateMonad MonadTrans.
+Existing Instance Monad_stateT.
 From FreeSpec.Core Require Import Interface Semantics Contract.
 
 Notation instrument Ω i := (stateT Ω (state (semantics i))).


### PR DESCRIPTION
for compatibility with coq-community/coq-ext-lib#106