### PR TITLE
Core requires OCaml >= 4.10

### DIFF
--- a/coq-freespec-core.opam
+++ b/coq-freespec-core.opam
@@ -23,7 +23,7 @@ build: [
 ]
 
 depends: [
-  "ocaml"
+  "ocaml" {>= "4.10"}
   "dune" {>= "2.5"}
   "coq" {>= "8.12" & < "8.14~" | = "dev"}
   "coq-ext-lib" {>= "0.11.2" | = "dev"}


### PR DESCRIPTION
https://github.com/lthms/FreeSpec/blob/d4e2f3a3fc7e82effddca202a8b0210dbbcf3663/theories/Core/gen_type_classes.ml#L25

[`List.concat_map`](https://v2.ocaml.org/api/List.html#VALconcat_map) was first introduced in ocaml/ocaml#8760